### PR TITLE
Windows 10 App Essentials 21.01

### DIFF
--- a/get.php
+++ b/get.php
@@ -138,7 +138,7 @@ $addons = array(
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/20.11/wintenApps-20.12.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.01/wintenApps-21.01.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2.0/wordCount-2.0.nvda-addon",
 	"wetp" => "http://www.nvda.it/files/plugin/weather_plus7.6.nvda-addon",


### PR DESCRIPTION
Windows 10 App Essentials 21.01 is a major release that will require NVDA 2020.3 or later. It is also the last version to support Windows 10 Version 1909 (November 2019 Update/build 18363).

## Release information:

* Name: Windows 10 App Essentials
* Author: Joseph Lee, Derek Rimer and contributors
* Repo: https://github.com/josephsl/wintenapps
* Branch: stable (tag: 21.01)
* Update channel: stable
* NVDA compatibility: 2020.3 and later

Changelog:

* NVDA 2020.3 or later is required.
* Various workarounds that were included with the add-on are now part of NVDA. These include reading Open With dialog content and better recognition of progressive web apps (PWA's) hosted by WWA Host process.
* Removed app modules for Open With dialog and WWA Host process.
* UIA help text (description change) property event is now tracked.
* Calculator: NVDA will once again announce calculator history and memory entries in version 10.2009 and later.

## Remark:
Please merge this PR before merging in NVDA Core PR 11909 as WinTenApps 21.01 removes usage of winVersion.winVersion as the NVDA Core PR 11909 removes it from NVDA.

Thanks.