### PR TITLE
Windows 10 App Essentials 21.02

### DIFF
--- a/get.php
+++ b/get.php
@@ -138,7 +138,7 @@ $addons = array(
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.01/wintenApps-21.01.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.02/wintenApps-21.02.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2.0/wordCount-2.0.nvda-addon",
 	"wetp" => "http://www.nvda.it/files/plugin/weather_plus7.6.nvda-addon",


### PR DESCRIPTION
Hi,

A companion pull request was submitted to add-on store submission repo hosted by NV Access:

## Release information:

* Name: Windows 10 App Essentials
* Version: 21.02
* Author: Joseph Lee, Derek Riemer and contributors
* Repo: https://github.com/josephsl/wintenapps
* Update channel: stable
* Release branch: stable (tag: 21.02)
* NVDA compatibility: 2020.3 and later

Changelog: requires Windows 10 Version 2004 (May 2020 Update/build 19041), initial support for updated emoji panel in Insider Preview build 21296 and later.

Thanks.