### PR TITLE
StationPlaylist 21.02

### DIFF
--- a/get.php
+++ b/get.php
@@ -110,7 +110,7 @@ $addons = array(
 	"rsy-o" => "https://github.com/nvdaes/reportSymbols/releases/download/3.6/reportSymbols-3.6.nvda-addon",
 	"sentencenav" => "https://github.com/mltony/nvda-sentence-nav/releases/download/v2.9/SentenceNav-2.9.nvda-addon",
 	"spie" => "https://www.nvaccess.org/files/nvda-addons/speechPlayerInEspeak-0.4.nvda-addon",
-	"spl" => "https://github.com/josephsl/stationPlaylist/releases/download/21.01/stationPlaylist-21.01.nvda-addon",
+	"spl" => "https://github.com/josephsl/stationPlaylist/releases/download/21.01/stationPlaylist-21.02.nvda-addon",
 	"spl-lts20" => "https://github.com/josephsl/stationPlaylist/releases/download/21.01/stationPlaylist-20.09.5-lts.nvda-addon",
 	"spl-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=spl-dev",
 	"sps" => "https://github.com/jscholes/nvda-speech-history/releases/download/2020.2/speechHistory-2020.2.nvda-addon",


### PR DESCRIPTION
## Release information:

* Name: StationPlaylist
* Author: Geoff Shang, Joseph Lee and contributors
* Repo: https://github.com/josephsl/stationPlaylist
* Version: 21.02
* Branch: 21.01.x (no tag)
* Update channel: stable
* NVDA compatibility: 2020.3 or later
Changelog:

* Columns explorer commands and encoder status announcements will work properly if NVDA is started while focused on a track in Studio or encoders. This is applicable to NVDA 2020.4 or later.
* NVDA will no longer fial to save encoder settins after errors are encountered when loading settings at startup.

Note: version 21.02 backports critical bug fixes from upcoming 21.03 release.

Thanks.