### PR TITLE
Update Weather_Plus to 7.7

### DIFF
--- a/get.php
+++ b/get.php
@@ -142,7 +142,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.02/wintenApps-21.02.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2.0/wordCount-2.0.nvda-addon",
-	"wetp" => "http://www.nvda.it/files/plugin/weather_plus7.6.nvda-addon",
+	"wetp" => "https://www.nvda.it/files/plugin/weather_plus7.7.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0-dev-20200306/winMag-1.0-dev-20200306.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0-dev-20200306/winMag-1.0-dev-20200306.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.2/winWizard-5.0.2.nvda-addon",


### PR DESCRIPTION
- Add-on name: Weather_Plus
- Author: Adriano Barbieri
- Version: 7.7
- Warning: Last NVDA version tested: 2021.2

Note: I have explained to the author that changes maybe required before accepting this PR. I'm not sure about your criteria here, since NVDA 2021.2 is not released and backward compatibility version number will be changed before the first beta of NVDA 2021, so we don't need to update this number for now.

🤔