### PR TITLE
Update Channel Selector initial (1.0.2) by Jose Manuel Delicado)

### DIFF
--- a/get.php
+++ b/get.php
@@ -133,6 +133,7 @@ $addons = array(
 	"tz" => "https://github.com/munawarb/NVDA-Time-Zoner/releases/download/v1.04/timezone-1.04.nvda-addon",
 	"ubi" => "https://github.com/leonardder/unicodebrailleinput/releases/download/3.1/unicodeBrailleInput-3.1.nvda-addon",
 	"ubi-dev" => "https://github.com/leonardder/unicodebrailleinput/releases/download/3.1/unicodeBrailleInput-3.1.nvda-addon",
+	"updchannelselect" => "https://github.com/nvda-es/updateChannel/releases/download/v1.0.2/updateChannel-1.0.2.nvda-addon",
 	"VR" => "virtualRevision-3.0.nvda-addon",
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",


### PR DESCRIPTION
Hi,

This add-on was reviewed in 2019 and now being registered for community distribution (ap9ologies for this lateness)...

## Update Channel Selector

### Introduction:

This add-on allows users to select update chanel for NVDA screen reader without having to visit snapsthos page.

## Release information:

* Name: Update Channel Selector
* Author: jose Manuel Delicado
* Repo: https://github.com/nvda-es/updateChannel
* Version: 1.0.2
* Add-on update channel: stable
* NVDA compatibility: 2019.1 to 2020.4
* Add-on files update key: updchannelselect
* Basic review reference thread: https://nvda-addons.groups.io/g/nvda-addons/topic/34396512#10965
* Basic review: license and copyright/pass, documentation/pass, security/pass, user experience/pass

Thanks.