### PR TITLE
Proxy support 1.0.2 (initial)

### DIFF
--- a/get.php
+++ b/get.php
@@ -76,6 +76,7 @@ $addons = array(
 	"numpadNav" => "https://github.com/opensourcesys/numpadNavMode/releases/download/1.3/numpadNavMode-1.3.nvda-addon",
 	"nvda3208" => "https://github.com/josephsl/addonUpdater/releases/download/21.05/addonUpdater-21.05.nvda-addon",
 	"nvda7857" => "screenCurtain-20191130.nvda-addon",
+	"nvdaproxy" => "https://github.com/nvda-es/nvda-proxy-support/releases/download/v1.0.2/proxy-1.0.2.nvda-addon",
 	"nvdaremote" => "https://nvdaremote.com/remote-2.3.nvda-addon",
 	"nvsp" => "https://www.nvaccess.org/files/nvda-addons/nvSpeechPlayer_2020.1.nvda-addon",
 	"objLoc" => "https://github.com/josephsl/objLocationTones/releases/download/20.12/objLocTones-20.12.nvda-addon",


### PR DESCRIPTION
## Proxy support for NVDA
### Introduction:
This add-on allows the NVDA screen reader to connect to the Internet through one or more proxy servers. To make it possible, it applies various patches to the standard Python library or modifies certain environment variables, depending on the chosen configuration. You will be able to update NVDA and their add-ons automatically from your corporate environment and even perform remote sessions, provided that your organization proxy server allows it.
## Release information:

* Name: proxy support
* Author: José Manuel Delicado
* Repo: https://github.com/nvda-es/nvda-proxy-support
* Version: 1.0.2
* Add-on update channel: stable
* NVDA compatibility: 2019.3 to 2020.4
* Add-on files update key: nvdaproxy
* Basic review reference thread: https://nvda-addons.groups.io/g/nvda-addons/topic/79148064
* Basic review: license and copyright/pass, documentation/pass, security/pass (last recomendations by @javidominguez applied), user experience/pass

Thanks.