### PR TITLE
Windows 10 App Essentials 21.06

### DIFF
--- a/get.php
+++ b/get.php
@@ -138,7 +138,7 @@ $addons = array(
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.10/VLC-2.10.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.04/wintenApps-21.04.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.06/wintenApps-21.06.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2.0/wordCount-2.0.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus7.7.nvda-addon",


### PR DESCRIPTION
## Release information:

* Name: Windows 10 App Essentials
* Author: Joseph Lee, Derek Riemer and contributors
* Repo: https://github.com/josephsl/wintenapps
* Version: 21.06
* Update channel: stable
* NVDA compatibility; 2020.4 and beyond
* Windows compatibility: 10.0.19041 and later
* SHA 256: 169ac65c46f72978a6a76c0cf41d05961720a8041b5902623ab655a459bb8e7b

Changelog:

* NVDA 2020.4 or later is required.
* The following UIA events were renamed to make them consistent with actual UI Automation event names: drag target enter to drop target enter, drag target leave to drop target leave, drag target dropped to drop target dropped.
* Modern keyboard: in build 21300 and later, with focus mode active from places such as web browsers, NVDA will no longer announce blank when using the arrow keys to navigate among emojis.
* Modern keyboard: when pressing Escape key to close emoji panel or clipboard history in build 21300 and later, focus will move back to the control you were working on before modern keyboard interface was opened. In some cases, Escape key should be pressed twice.

Thanks.