### PR TITLE
Update WinWizard to version 5.0.3

### DIFF
--- a/get.php
+++ b/get.php
@@ -144,7 +144,7 @@ $addons = array(
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus7.7.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0-dev-20200306/winMag-1.0-dev-20200306.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0-dev-20200306/winMag-1.0-dev-20200306.nvda-addon",
-	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.2/winWizard-5.0.2.nvda-addon",
+	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",
 	"wordnav" => "https://github.com/mltony/nvda-word-nav/releases/download/v1.2/wordNav-1.2.nvda-addon",
 	"zoom" => "zoomEnhancements-1.0.nvda-addon",
 );


### PR DESCRIPTION
This pull request   updates link to the WinWizard to the version 5.03. which is compatible with NVDA  2021.1.
https://github.com/lukaszgo1/winWizard/tree/V5.0.3

No code changes aside from updating last tested NVDA version were necessary however I've updated the readme to note that the new release is compatible with 2021.1 and I would be grateful if it could be updated on the website. Alternatively I'm  happy to do it myself if I'm told how to do so.