### PR TITLE
Update Weather_Plus to 8.1

### DIFF
--- a/get.php
+++ b/get.php
@@ -141,7 +141,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.06/wintenApps-21.06.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
-	"wetp" => "https://www.nvda.it/files/plugin/weather_plus7.7.nvda-addon",
+	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.1.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0/winMag-1.0.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0/winMag-1.0.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",


### PR DESCRIPTION
## Release information
- Add-on name: Weather_Plus
- Author: Adriano Barbieri
- Version: 8.1
- NVDA compatibility: 2017.3 and beyond
- url: https://www.nvda.it/weather-plus/

## Note

Pull request created on behalf of the author:

https://nvda-addons.groups.io/g/nvda-addons/message/15862