### PR TITLE
Windows 10 App Essentials 21.06.1

### DIFF
--- a/get.php
+++ b/get.php
@@ -138,7 +138,7 @@ $addons = array(
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.06/wintenApps-21.06.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.06.1/wintenApps-21.06.1.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus7.7.nvda-addon",


### PR DESCRIPTION
Note: Windows 10 App Essentials will be renamed to Windows App Essentials soon.

## Release information:

* Name: Windows 10 App Essentials
* Author: Joseph Lee and contributors
* Repo: https://github.com/josephsl/wintenapps
* Version: 21.06.1
* Update channel: stable
* NVDA compatibility: 2020.4 to 2021.1
* SHA256: 2deb6a91f96945bff17717039cb62e4a93d1d4fcc04666bde468602263e6d250

Changelog: Windows 11 Insider Preview (build 22000) is being tested by Insiders. It might be possible that people might install stable versions of this add-on in Windows 11, therefore a warning dialog was added. If the user chooses to install the add-on on Windows 11 despite warnings, a Windows 11 detection message will be logged every time NVDA starts. The warning dialog and the detection message will be gone once Windows 11 is released to the general public later this year.

Thanks.