### PR TITLE
Windows App Essentials 21.08

### DIFF
--- a/get.php
+++ b/get.php
@@ -139,7 +139,7 @@ $addons = array(
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.06.1/wintenApps-21.06.1.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.08/wintenApps-21.08.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.1.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 21.08
- Update channel: stable
- NVDA compatibility: 2020.4 and beyond
- Sha256: 67a338c7e4c2766fbef52eeaf09412f50a265b934b570686f70408d9477d2b13
### Changelog (mention changes in separate lines starting with dash space)
* Initial support for Windows 10 Version 21H2 (Second 2021 Update), unofficial support for Windows Server 2022. These two releases have different build numbers.
* Requires Windows 10 Version 20H2 or later.
* Experimental support for Windows 11, not to be confused with Windows 10 Version 21H2.
* Windows Search (formerly classic Cortana) and modern keyboard app modules were renamed to reflect executable names for these apps in Version 2004 and later.
* Removed app module for combined Mail and Calendar (experimental version) as separate apps were reinstated in late 2020.
* The ability to track and log events for most events is handled by a new add-on named Event Tracker. Consequently, tracking events such as name change and controler for events is deprecated and will be removed in a future release.
* In search fields, NVDA can announce suggestions count whenever suggestions list changes as opposed to only when suggestions are first shown.
* Added support for layout invalidated UIA event, used to announce suggestions count changes as search terms are entered.
* When tracking events, information specific to certain events such as suggestion count for layout invalidated event will be logged separately from general information such as UIA element and Automation Id.
* Removed additional dialog class names as the only place where it was applicable (Windows Insider Program sign up screen) is no longer a dialog.
* Settings: in Settings/Update and Security/Recovery/Reset, initial progress messages and content changes are announced even when selective UIA event registration is active.
* Windows Search/File Explorer: in Windows 11, NVDA will no longer fail to announce suggestion count, caused by the Windows Search executable being renamed.

### Additional information
A follow-up release (21.09) will be released in late August to incorporate changes made to Windows 11 by then.
