### PR TITLE
Update Weather_Plus to version 8.4

### DIFF
--- a/get.php
+++ b/get.php
@@ -142,7 +142,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.08/wintenApps-21.08.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
-	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.1.nvda-addon",
+	"wetp" => "https://github.com/ruifontes/Weather_Plus/releases/download/8.4/Weather_Plus8.4.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0/winMag-1.0.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V1.0/winMag-1.0.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",


### PR DESCRIPTION
<!-- Please read and fill in the following template.

Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
-->

### Release information
- Name: Weather_Plus
- Author: Adriano Barbieri
- Repo: https://github.com/ruifontes/Weather_Plus
- Version: 8.4
- Update: Stable
- NVDA compatibility: 2017.3 and beyond

### Changelog (mention changes in separate lines starting with dash space)
- Fixed copy function of partial text selection using control + c, and enabled the home, end and pageup keys, pagedown in enabled windows.
- Correct response pressure in mmHg.

### Additional information
- Update Weather_Plus to version 8.4;
- The change log is only from the last version;
- Change repository to:
https://github.com/ruifontes/Weather_Plus
by request of author, Adriano Barbieri

