### PR TITLE
Windows App Essentials 21.09

### DIFF
--- a/get.php
+++ b/get.php
@@ -142,7 +142,7 @@ $addons = array(
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.08/wintenApps-21.08.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.09/wintenApps-21.09.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
 	"wetp" => "https://github.com/ruifontes/Weather_Plus/releases/download/8.4/Weather_Plus8.4.nvda-addon",


### PR DESCRIPTION

### Release information
- Name: Windows App Essentials
- Author: Joseph Lee
- Repo: https://github.com/josephsl/wintenapps
- Version: 21.09
- Update channel: stable
- NVDA compatibility: 2020.4 and later (note that "beyond" is similar to "later")
- SHA256: 471e42973826753d0d17e6eab6085d7cb8a430e0526696a6a4df7b62b555617f

### Changelog (mention changes in separate lines starting with dash space)
- On systems running Windows Server releases such as Server 2022, a warning dialog will be presented when installing the add-on as most modern apps such as Microsoft Store are not present in server systems, thereby limiting add-on features.
- When using Add-on Updater to update this add-on on unsupported Windows releases, the warning dialog will resemble the one shown when installing the add-on manually by being specific about minimum supported Windows release.
- Removed dedicated search field support and transferred suggestions count announcement to a dedicated suggestions list view object.
- Calculator: added support for redesigned Calculator (version 10.2109) included in Windows 11.
- Calculator: removed memory and history item workaround in Calculator 10.2109 as these items have labels.
- Modern keyboard: in Windows 11, it is no longer required to press the Escape key twice to close combined emoji panel and clipboard history.

### Additional information
Version 21.09 is a minor update responding to Windows 11 development. The next version (21.10) is a major update that will require NVDA 2021.2 or later.

Thanks.