### PR TITLE
Add Quick Notetaker

### DIFF
--- a/get.php
+++ b/get.php
@@ -99,6 +99,7 @@ $addons = array(
 	"phoneticpunc" => "https://github.com/mltony/nvda-phonetic-punctuation/releases/download/v1.3/phoneticPunctuation-1.3.nvda-addon",
 	"qb-dev" => "https://www.nvaccess.org/files/nvda-addons/quickBooks2014-2014.4.7.nvda-addon",
 	"quickdictionary" => "https://github.com/grisov/quickDictionary/releases/download/latest/quickDictionary-2.1.4.nvda-addon",
+	"quickNotetaker" => "https://github.com/mohammad-suliman/quickNotetaker/releases/download/v1.0/quickNotetaker-1.0.nvda-addon",
 	"rccp" => "https://github.com/tuukkao/nvda-reviewCursorCopier/releases/download/1.3/reviewCursorCopier-1.3.nvda-addon",
 	"rccp-dev" => "https://github.com/tuukkao/nvda-reviewCursorCopier/releases/download/1.3/reviewCursorCopier-1.3.nvda-addon",
 	"rf" => "https://github.com/nvdaes/readFeeds/releases/download/12.0/readFeeds-12.0.nvda-addon",
@@ -151,7 +152,6 @@ $addons = array(
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",
 	"wordnav" => "https://github.com/mltony/nvda-word-nav/releases/download/v1.4/wordNav-1.4.nvda-addon",
 	"zoom" => "zoomEnhancements-1.1.1.nvda-addon",
-	"quickNotetaker" => "quickNotetaker-1.0.nvda-addon",
 );
 
 If (isset($_GET['file'])) {


### PR DESCRIPTION
<!-- Please read and fill in the following template.

Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
-->

### Release information
- Name (Example, Add-on Updater): Quick Notetaker
- Author (example, Your Name): Eilana Benish, Mohammad Suliman
- Repo (example, https://github.com/yourname/addonName): https://github.com/mohammad-suliman/quickNotetaker
- Version (example, 21.07): 1.0
- Update channel (example, stable, dev or stable and dev): stable
- NVDA compatibility (example, 2021.1 and beyond): 2019.3 and later

### Changelog (mention changes in separate lines starting with dash space)

This is the first release! Hope you will enjoy it! Stay tuned for new features in the next releases.

### Additional information

The Quick Notetaker add-on is a wonderful tool which allows writing notes quickly and easily anytime and from any app the user is using. Whether the user is watching a video for example, or participating in a meeting on Zoom, teams or Google meet, they can easily and smoothly open the notetaker and take a note. In order to create a quick note, NVDA + Alt + n key combination can be used, a floating window appears at the top left corner of the screen, so the note can be typed there.
Every note that is being Created can optionally get the active window title, and as such, the note content can get the context in which this note was created by having the note title as the active window title the user was using. This behavior can be changed from the add-on settings, where the user can decide whether the active window title is captured when creating a new note.
