### PR TITLE
Windows App Essentials 21.11

### DIFF
--- a/get.php
+++ b/get.php
@@ -143,7 +143,7 @@ $addons = array(
 	"vlc-18" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.12/VLC-2.12.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.10/wintenApps-21.10.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.11/wintenApps-21.11.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
 	"wetp" => "https://github.com/ruifontes/Weather_Plus/releases/download/8.4/Weather_Plus8.4.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 21.11
- Update channel: stable
- NVDA compatibility: 2021.2 and later
- Sha256: 27612d0267273fd30b45536cbeb397a795cbe81666c594e907cbea0a1ecff6e1

### Changelog (mention changes in separate lines starting with dash space)
- Partially removed the ability to recognize additional dialogs as recent Windows and app updates improve NVDA's ability to detect dialogs without help from the add-on. Dialogs with UIA class names included in NVDA will still be detected.
- The debug log prefix was changed from "W10" to "winapps" to reflect the renamed add-on.
- It is no longer required to enable report object position information option from NVDA's object presentation settings to be notified about suggestion count when searching in various apps.
- Roles for headings found in apps such as Settings app are properly marked as headings when displaying developer info for navigator object (NVDA+F1).
- Microsoft Store: removed download list item label workaround in Windows 10 Store as the item label includes download status.
- Modern keyboard: in Windows 11, IME and hardware input suggestion candidate items are no longer announced twice.

### Additional information

