### PR TITLE
Windows App Essentials 22.01

### DIFF
--- a/get.php
+++ b/get.php
@@ -142,7 +142,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/21.11/wintenApps-21.11.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.01/wintenApps-22.01.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
 	"wetp" => "https://github.com/ruifontes/Weather_Plus/releases/download/8.4/Weather_Plus8.4.nvda-addon",


### PR DESCRIPTION
<!-- Please read and fill in the following template.

Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
-->

### Release information
- Name: Windows App Essentials
- Author: Joseph Lee
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.01
- Update channel: stable
- NVDA compatibility: 2021.2 and later
- Sha256: 644a370d40678c1699f80a7ad90b3dbc6f652cbe7f2a8328743aa38a871e3d3f

### Changelog (mention changes in separate lines starting with dash space)
- Transferred layout invalidated event tracking and logging to Event Tracker add-on.
- The following UIA events are no longer tracked and logged due to lack of useful information: drag start, drag cancel, drop target enter, drop target leave.
- XAML heading recognition is deprecated and will be removed in a future release as it caused problems in apps such as Calculator and Settings.
- Removed app modules for File Explorer and Microsoft Store as Store version 2 (Windows 10/11) provides better support for download progress announcements without using the app module.
- Added support for Windows 11 Notepad.
- File Explorer: due to compatibility issues with other add-ons, File Explorer app module was removed which may cause increased verbosity when switching between apps in Windows 11. The fix for "pane" announcement issue when switching apps is not affected.
- Notepad (Windows 11 preview): NVDA will announce status items such as line and column information when report status bar command (NVDA+End in desktop layout, NvDA+Shift+End in laptop layout) is performed.
- Notepad (Windows 11 preview): NVDA will no longer announce entered text when pressing Enter key from the document.
- Settings: in Windows 11, breadcrumb bar items are properly recognized.

### Additional information
This is the last version to support Windows 10 Version 20H2 (October 2020 Update).
