### PR TITLE
Access8Math 3.2

### DIFF
--- a/get.php
+++ b/get.php
@@ -1,6 +1,6 @@
 <?php
 $addons = array(
-	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.1/Access8Math-3.1.nvda-addon",
+	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.2/Access8Math-3.2.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/21.05/addonsHelp-21.05.nvda-addon",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"ath-dev" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Access8Math
- Author: Tseng Woody
- Repo: https://github.com/tsengwoody/Access8Math
- Version: 3.2
- Update channel: stable
- NVDA compatibility: 2019.3~2021.3.1

### Changelog (mention changes in separate lines starting with dash space)

- New feature "`" to separate data blocks, the blocks enclosed by "`" are AsciiMath data
- New feature editing-shortcut for browse navigation mode cut (ctrl+x), copy (ctrl+c), paste (ctrl+v), delete (delete/back space)
- New feature moving-shortcut for browse navigation mode move between interactive data blocks (tab), move between AsciiMath data blocks (a)
- Change move cursor way in browse navigation mode - move cursor way with up, down, left and right arrow keys and read out the contents of the data block after the movement.
- When the cursor moves in the browse navigation mode, the math data block will read the serialized textual content of math instead of the source code
- When the cursor is in the math data block in the browse navigation mode, press the space or enter key to interact with the math data block.
- New feature English letters as shortcut keys that can be setted 
- New feature greek alphabet shortcut gesture
- Shortcut key input is only apply in the LaTeX area 
- set using audio or speech indicate to switching of browse navigation mode 
- The LaTeX command menu can be opened in the text area and insert LaTeX separators when LaTeX command inserting
- New feature translation menu, which can convert the LaTeX/AsciiMath data format of the block where the cursor is located. It belongs to the command gesture group. When the cursor is in the LaTeX/AsciiMath block, press alt+t to open the translation menu (in the browse navigation mode, ctrl+t)
- New feature batch menu, which can convert the entire document LaTeX/AsciiMath data format to each other, and can convert the LaTeX separator between brackets and dollar. It belongs to the command gesture group. Press alt+b to open the batch menu
- Added MathML block type, support alt+i, single letter navigation "m", tab movement in browse navigation mode
- New feature braille custom-defined math rules and unicode dictionary, which are the same as speech
- The exported HTML can show with markdown
- The exported HTML is added page title and file name by notepad window title.

### Additional information

