### PR TITLE
Update BrowserNav

### DIFF
--- a/get.php
+++ b/get.php
@@ -11,7 +11,7 @@ $addons = array(
 	"bgt" => "https://github.com/sykesman/NVDA-BGT/releases/download/1.0-dev/bgt_lullaby-1.0-dev.nvda-addon",
 	"brlext" => "https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest",
 	"brlext-dev" => "https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest?channel=dev",
-	"browsernav" => "https://github.com/mltony/nvda-browser-nav/releases/download/v1.15.1/browsernav-1.15.nvda-addon",
+	"browsernav" => "https://github.com/mltony/nvda-browser-nav/releases/download/v2.2/browsernav-2.2.nvda-addon",
 	"btaudio" => "https://github.com/mltony/nvda-bluetooth-audio/releases/download/v1.3/bluetoothaudio-1.3.nvda-addon",
 	"cac" => "https://github.com/hkatic/clock/releases/download/v21.11/clock-21.11.nvda-addon",
 	"cac-dev" => "https://github.com/hkatic/clock/releases/download/v21.11/clock-21.11.nvda-addon",


### PR DESCRIPTION
## BrowserNav v2.2
* Repo: https://github.com/mltony/nvda-browser-nav
* Compatibility with NVDA 2021.

* Introduces bookmarks: QuickJump, QuickClick, SkipClutter and Hierarchical.
* Performance improvement in Chrome and Firefox.
* Introduces optional ignoring focus events and muting live regions.
* Fixed QuickNav T command to jump to the first cell of the table.
* Bugfixes.
