### PR TITLE
updated beepKeyboard to 1.7 version.

### DIFF
--- a/get.php
+++ b/get.php
@@ -7,7 +7,7 @@ $addons = array(
 	"audiochart" => "https://github.com/mltony/nvda-audio-chart/releases/download/v1.3/audioChart-1.3.nvda-addon",
 	"bc" => "bitChe-2.8.nvda-addon",
 	"bc-dev" => "bitChe-2.8.nvda-addon",
-	"beepkeyboard" => "beepKeyboard-1.3.nvda-addon",
+	"beepkeyboard" => "https://github.com/davidacm/beepKeyboard/releases/download/1.7/beepKeyboard-1.7.nvda-addon",
 	"bgt" => "https://github.com/sykesman/NVDA-BGT/releases/download/1.0-dev/bgt_lullaby-1.0-dev.nvda-addon",
 	"brlext" => "https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest",
 	"brlext-dev" => "https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest?channel=dev",


### PR DESCRIPTION
### Release information
- Name: Beep keyboard.
- Author: David CM
- Repo: https://github.com/davidacm/beepKeyboard
- Version: 1.7
- Update channel: stable
- NVDA compatibility: from 2018.3 to 2021.3.1

### Changelog (mention changes in separate lines starting with dash space)

- updated manifest to support NVDA 2021.3.1.
- updated readme
- added a check to disable toggle beeping if toggle keys in ease of access is enabled, since this feature can be enabled on the system but doesn't work very well for NVDA with laptop keyboard layout.