### PR TITLE
Update WordNav

### DIFF
--- a/get.php
+++ b/get.php
@@ -149,7 +149,7 @@ $addons = array(
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V1.1/winMag-1.1.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V1.1/winMag-1.1.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",
-	"wordnav" => "https://github.com/mltony/nvda-word-nav/releases/download/v1.4/wordNav-1.4.nvda-addon",
+	"wordnav" => "https://github.com/mltony/nvda-word-nav/releases/download/v1.7/wordNav-1.7.nvda-addon",
 	"zoom" => "zoomEnhancements-1.1.1.nvda-addon",
 );
 


### PR DESCRIPTION
## WordNav v1.7
* Repo: https://github.com/mltony/nvda-word-nav
* Fixed behavior in Google Chrome. Due to a bug in Chrome implementation of IAccessible2, setCaretOffset method doesn't work in multiline text areas. Using a hack with setSelection method instead. Please keep in mind that the real caret position is only updated when Control key is released. please keep in mind to release Control key after pressing left and right arrows and before issueing any other keystrokes.
* Performance optimization in VSCode.
* Added  custom regular expression word. Settings now allows to specify custom regular expression instead of list of punctuation marks.
* Added chime when crossing paragraphs.
* Compatibility with NVDA 2022.
