### PR TITLE
Sound Splitter 22.02 (initial release)

### DIFF
--- a/get.php
+++ b/get.php
@@ -115,6 +115,7 @@ $addons = array(
 	"rsy-o" => "https://github.com/nvdaes/reportSymbols/releases/download/3.6/reportSymbols-3.6.nvda-addon",
 	"searchwith" => "https://github.com/ibrahim-s/searchWith/releases/download/v1.9/searchWith-1.9.nvda-addon",
 	"sentencenav" => "https://github.com/mltony/nvda-sentence-nav/releases/download/v2.11/SentenceNav-2.11.nvda-addon",
+	"soundsplitter" => "https://github.com/josephsl/soundSplitter/releases/download/22.02/soundSplitter-22.02.nvda-addon",
 	"spie" => "https://www.nvaccess.org/files/nvda-addons/speechPlayerInEspeak-0.4.nvda-addon",
 	"spl" => "https://github.com/josephsl/stationPlaylist/releases/download/22.01/stationPlaylist-22.01.nvda-addon",
 	"spnav" => "https://github.com/Nardol/SayProductNameAndVersion/releases/download/2021.07/sayProductNameAndVersion-2021.07.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Sound Splitter
- Author: Joseph Lee
- Repo: https://github.com/josephsl/soundsplitter
- Version: 22.02
- Update channel: stable
- NVDA compatibility: 2019.3 and later
- Sha256: becd01dea8c51f35896ca13c9b8c725d527c72fc5bc4201139d8d01f14622d8a

### Changelog (mention changes in separate lines starting with dash space)
- Initial release based on Tony's Enhancements.

### Additional information
Sound Splitter code was originally part of Tony's Enhancements and was split with blessing from Tony Malykh.
