### PR TITLE
Windows App Essentials 22.02

### DIFF
--- a/get.php
+++ b/get.php
@@ -143,7 +143,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.01/wintenApps-22.01.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.02/wintenApps-22.02.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
 	"wetp" => "https://github.com/ruifontes/Weather_Plus/releases/download/8.4/Weather_Plus8.4.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.02
- Update channel: stable
- NVDA compatibility: 2021.2 and later
- Sha256: dcd164b393845c9da8c34d4b8003ef6bac1e345d465142fd6ad05916c97d586f

### Changelog (mention changes in separate lines starting with dash space)
- Windows 10: Requires Version 21H1 or later.
- In Windows 11, microphone mute status is announced from anywhere when Windows+Alt+K is pressed.
- Notepad (Windows 11 preview): Provided that status bar is checked from View menu, NVDA will no longer announce status bar information such as line number from places other than documetn edit window.

### Additional information
