### PR TITLE
Update Weather_Plus to 8.7, requested by author (Adriano Barbieri)

### DIFF
--- a/get.php
+++ b/get.php
@@ -147,7 +147,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.02/wintenApps-22.02.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
-	"wetp" => "https://github.com/ruifontes/Weather_Plus/releases/download/8.4/Weather_Plus8.4.nvda-addon",
+	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.7.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V1.1/winMag-1.1.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V1.1/winMag-1.1.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Weather_Plus
- Author: Adriano Barbieri
- Repo: https://github.com/ruifontes/Weather_Plus/
- Version: 8.7
- Update channel: stable
- NVDA compatibility: 2017.3 and beyond

### Changelog
- Added "en" folder missing in the documentation. 
- if the Copy the weather report and weather forecast, including city details to clipboard item is enabled, pressing nvda + alt + w will now also copy the date of the last update of the bulletin to the clipboard.

### Additional information
The author (Adriano Barbieri) has requested me to create this PR. Release information and changelog, including repo,  are copied from info sent privately by the author.
cc: @ruifontes

