### PR TITLE
Expanded readme with more sections and details, to better explain the addonFiles process

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ To include a new add-on:
 2. Fork this repo (nvaccess/addonFiles) into your own GitHub account.
 3. Create a new branch in your forked version of addonFiles.
 4. In your new branch, edit the get.php file, as described below.
-5. Push the new branch to your fork, and issue a pull request to merge it into this repository.
+5. Push the new branch to your fork, and issue a pull request to merge it into this repository. When creating the pull request, be sure to follow the instructions that appear in the edit field on GitHub.
 
 Your pull request will be reviewed, and if approved, will be merged, thus making your changes to get.php part of the official add-ons website as described below.
 

--- a/readme.md
+++ b/readme.md
@@ -6,14 +6,29 @@ This fork was created so that NV Access could review changes to the add-on websi
 
 ### New Add-ons:
 
-To include a new add-on, host it (ideally on GitHub, the [add-on template](https://github.com/nvdaaddons/addontemplate) makes this easy), and edit the get.php file.
+To include a new add-on:
+1. Host it (ideally on GitHub, the [add-on template](https://github.com/nvdaaddons/addontemplate) makes this easy).
+2. Fork this repo (nvaccess/addonFiles) into your own GitHub account.
+3. Create a new branch in your forked version of addonFiles.
+4. In your new branch, edit the get.php file, as described below.
+5. Push the new branch to your fork, and issue a pull request to merge it into this repository.
+
+Your pull request will be reviewed, and if approved, will be merged, thus making your changes to get.php part of the official add-ons website as described below.
+
+#### Get.php for New Add-ons:
+
 You need to make sure to have a unique key (add-on ID) in get.php for your add-on.
+We needed unique keys because [Ikiwiki](https://ikiwiki.info) doesn't seem to like long links, such as would be formed by the full add-on name..
+
+#### Get.php for Updated Add-ons:
+
+Find your add-on's existing entry in get.php, and change the URL to point to your new version's direct download (That is, usually the part ending with "`.nvda-addon`").
+
+### Update Timing:
 
 The server pulls this repo once per hour, see [nvaccess/mrconfig/automatic.crontab](https://github.com/nvaccess/mrconfig/blob/master/automatic.crontab).
-Then the file will be available from:
+After your pull request is approved and merged, and the next hourly update occurs, the new/updated add-on will be available from:
 https://addons.nvda-project.org/files/get.php?file=key
-
-We needed this because [Ikiwiki](https://ikiwiki.info) doesn't seem to like long links.
 
 ### Reviewing updated add-on links:
 


### PR DESCRIPTION
After a recent discussion on NVDA-addons list, I realized that a dev who is admittedly not as active as previously, did not seem to understand the process for updating get.php, even after a referral to https://addons.nvda-project.org/requirements.en.html.

After reading that file again myself, I thought that it was thin on specific details, for anyone not already familiar with the process.

Not being able to edit that file, I thought I would try to improve readme.md here in addonFiles, as it appears to be the basis for the requirements file.

* Re-wrote the "New Add-ons" section, to better elaborate the process for devs not used to using addonFiles.
* Added a subsection called "Get.php for New Add-ons", containing both notes about unique keys in get.php.
* Added a subsection called "Get.php for Updated Add-ons", containing a brief note about how to update.
* Placed the hourly update and URL information under a heading called "Update Timing".
* Expanded the phrasing of "Update Timing" slightly, to be more complete about what is to be expected.
