### PR TITLE
Windows App Essentials 22.03.1

### DIFF
--- a/get.php
+++ b/get.php
@@ -144,7 +144,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.02/wintenApps-22.02.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.03/wintenApps-22.03.1.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/21.05/wordCount-21.05.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.8.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.03.1
- Update channel: stable
- NVDA compatibility: 2021.3 and later
- Sha256: 4ac787aa0fe089a06d4cf17af6d20c82a26b8b07ee1f4bba3750c401c7957568

### Changelog (mention changes in separate lines starting with dash space)
- NVDA 2021.3 or later is required, more so for security (NVDA 2021.3.3 is advised).
- Various features and fixes that were included with the add-on are now part of NVDA. These include announcing search suggestion count in apps such as Settings and Microsoft Store and "pane" no longer being announced when switching between apps in Windows 11.
- Installing and using the add-on on Windows Insider Preview builds between 20348 (Server 2022) and 22000 (Windows 11) is no longer supported.
- Removed the warning message when installing the add-on on Windows Server systems as the add-on is better optimized for Windows 10/11 client systems.
- Removed deprecated XAML heading detection feature.
- Removed the debug tone heard when UIA notification events come from background apps when debug log is on. Use Event Tracker add-on to debug UIA notification events.
- Removed Start menu size announcement workaround as it is no longer heard in recent Windows 10 releases.
- UIA drag drop effect property event is now tracked.
- More information is announced when arranging Start menu tiles or Action center quick actions with Alt+Shift+arrow keys such as potential location of the dragged tile and placement of Action center quick action.
- Calculator: NvDA will announce results when more commands are performed such as pressing equals (=) key and performing operations in scientific calculator mode such as trigonometric operations.
- Maps: Removed street side view workaround as it is no longer applicable in recent app releases.
- Modern keyboard: In Windows 11 clipboard history, browse mode will be turned off by default, designed to let NVDA announce clipboard history entry menu items.
- Settings: In Windows 10, update history items no longer include installation status to align with Windows 11.

### Additional information
Originally tagged as 22.03, bumped to 22.03.1 to add compatibility with NVDA 2022.1.
