### PR TITLE
Update addonsHelp

### DIFF
--- a/get.php
+++ b/get.php
@@ -1,7 +1,7 @@
 <?php
 $addons = array(
 	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.2/Access8Math-3.2.nvda-addon",
-	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/21.05/addonsHelp-21.05.nvda-addon",
+	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"ath-dev" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"audiochart" => "https://github.com/mltony/nvda-audio-chart/releases/download/v1.3/audioChart-1.3.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: addonsHelp
- Author: Rui Fontes <rui.fontes@tiflotecnia.com>, Ângelo Abrantes <ampa4374@gmail.com>, Zougane, Remy and Abdel
- Repo: https://github.com/ruifontes/addonsHelp
- Version: 2022.03
- Update channel: stable
- NVDA compatibility: 2022.1 and beyond): 

### Changelog (mention changes in separate lines starting with dash space)
- Modified manifest.ini to be compliant with NVDA 2022.1;
- Added russian translation

### Additional information

