### PR TITLE
New add-on applicationDictionary

### DIFF
--- a/get.php
+++ b/get.php
@@ -2,6 +2,8 @@
 $addons = array(
 	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.2/Access8Math-3.2.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
+	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03/applicationDictionary-2022.03.nvda-addon
+",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"ath-dev" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"audiochart" => "https://github.com/mltony/nvda-audio-chart/releases/download/v1.3/audioChart-1.3.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Application Dictionary
- Author: Rui Fontes <rui.fontes@tiflotecnia.com> and Ricardo Leonarczyk <ricardo.leonarczyk95@gmail.com>"
- Repo: https://github.com/ruifontes/applicationDictionary
- Version: 2022.03
- Update channel: stable
- NVDA compatibility: 2022.1 and beyond): 

### Changelog (mention changes in separate lines starting with dash space)
- First version submitted

### Additional information
## Usage
This simple add-on makes possible to create application-specific dictionaries for NVDA.
To use the add-on, just go to the application for wich you want a dictionary for, and press NVDA+shift+p.
The normal NVDA dictionary dialog will open for you to add entries valid only for the active application (the application name should appear in the dialog title).
The default add-on shortcut can be changed through NVDA's input gestures dialog: under configuration node, expand the node that says "Shows the application-specific dictionary dialog".

## Command
NVDA+Shift+p

## Automatic update
This add-on includes an automatic update feature.
The check for a new version will be executed everytime NVDA is loaded.
If you do not want this, go to NVDA, Preferences, Options and in the add-on category uncheck the check box.


