### PR TITLE
Windows App Essentials 22.03.2

### DIFF
--- a/get.php
+++ b/get.php
@@ -144,7 +144,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.03/wintenApps-22.03.1.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.03/wintenApps-22.03.2.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.8.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.03.2
- Update channel: stable
- NVDA compatibility: 2021.3 and later
- Sha256: 09cc8b0e9c811b79cd96b0b465d022ed184243eccb625a0d140ed39f0ce86e18

### Changelog (mention changes in separate lines starting with dash space)
- NVDA will no longer repeat text output in Windows Terminal 1.12.10733 and later (this fix is applicable to NVDA 2021.3.x as 2022.1 resolves this).

### Additional information
