### PR TITLE
New add-on applicationDictionary

### DIFF
--- a/get.php
+++ b/get.php
@@ -2,8 +2,7 @@
 $addons = array(
 	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.2/Access8Math-3.2.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
-	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03/applicationDictionary-2022.03.nvda-addon
-",
+	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03.26/applicationDictionary-2022.03.26.nvda-addon",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"ath-dev" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"audiochart" => "https://github.com/mltony/nvda-audio-chart/releases/download/v1.3/audioChart-1.3.nvda-addon",

--- a/get.php
+++ b/get.php
@@ -2,6 +2,8 @@
 $addons = array(
 	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.2/Access8Math-3.2.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
+	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03/applicationDictionary-2022.03.nvda-addon
+",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"ath-dev" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
 	"audiochart" => "https://github.com/mltony/nvda-audio-chart/releases/download/v1.3/audioChart-1.3.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: applicationDictionary
- Author: Rui Fontes <rui.fontes@tiflotecnia.com> and Ricardo Leonarczyk <ricardo.leonarczyk95@gmail.com> and colaboration of Cyrille Bougot
- Repo: https://github.com/ruifontes/applicationDictionary-
- Version: 2022.03.26
- Update channel: stable
- NVDA compatibility: 2019.3 and beyond

### Changelog (mention changes in separate lines starting with dash space)
- Compatibility changed to 2019.3 and beyond;
- Avoid duplication of "Application dictionary" submenu after reloading plugins;
- Thanks to Cyrille Bougot:
 - Dictionaries created before migration to a separate directory are now moved there automatically
 - Empty files are no longer created when opening dictionary dialog
 - Empty files are no longer pointlesly kept in the config
- Make not check updates at startup as default.

### Additional information
Authorized, long time ago, to submitt it again to oficial repo...
