### PR TITLE
Alternative faster PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,35 @@
-<!-- Please read and fill in the following template.
+<!-- Please read and fill in the template following this comment.
 
-Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
+Example:
+
+### Release information (place the required information for each item after the colon followed by space)
+
+- Name: Add-on Updater
+- Author: Joseph Lee
+- Repo: https://github.com/josephsl/addonUpdater
+- Version: 21.07, 20210815-dev
+- Update channel: stable and dev
+- NVDA compatibility: 2021.1 and beyond
+
+### Changelog (mention changes in separate lines starting with dash space)
+
+- updated translations.
+
+### Additional information
+
+Other info you consider important.
 -->
 
 ### Release information
-- Name (Example, Add-on Updater): 
-- Author (example, Your Name): 
-- Repo (example, https://github.com/yourname/addonName): 
-- Version (example, 21.07): 
-- Update channel (example, stable, dev or stable and dev): 
-- NVDA compatibility (example, 2021.1 and beyond): 
 
-### Changelog (mention changes in separate lines starting with dash space)
+- Name:
+- Author:
+- Repo:
+- Version:
+- Update channel:
+- NVDA compatibility:
+
+### Changelog
 
 ### Additional information
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,35 +1,17 @@
-<!-- Please read and fill in the template following this comment.
+<!-- Please read and fill in the following template.
 
-Example:
-
-### Release information (place the required information for each item after the colon followed by space)
-
-- Name: Add-on Updater
-- Author: Joseph Lee
-- Repo: https://github.com/josephsl/addonUpdater
-- Version: 21.07, 20210815-dev
-- Update channel: stable and dev
-- NVDA compatibility: 2021.1 and beyond
-
-### Changelog (mention changes in separate lines starting with dash space)
-
-- updated translations.
-
-### Additional information
-
-Other info you consider important.
+Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
 -->
 
 ### Release information
+- Name (Example, Add-on Updater): 
+- Author (example, Your Name): 
+- Repo (example, https://github.com/yourname/addonName): 
+- Version (example, 21.07): 
+- Update channel (example, stable, dev or stable and dev): 
+- NVDA compatibility (example, 2021.1 and beyond): 
 
-- Name:
-- Author:
-- Repo:
-- Version:
-- Update channel:
-- NVDA compatibility:
-
-### Changelog
+### Changelog (mention changes in separate lines starting with dash space)
 
 ### Additional information
 

--- a/.github/PULL_REQUEST_TEMPLATE/FASTER_PR.md
+++ b/.github/PULL_REQUEST_TEMPLATE/FASTER_PR.md
@@ -1,0 +1,35 @@
+<!-- Please read and fill in the template following this comment.
+
+Example:
+
+### Release information (place the required information for each item after the colon followed by space)
+
+- Name: Add-on Updater
+- Author: Joseph Lee
+- Repo: https://github.com/josephsl/addonUpdater
+- Version: 21.07, 20210815-dev
+- Update channel: stable and dev
+- NVDA compatibility: 2021.1 and beyond
+
+### Changelog (mention changes in separate lines starting with dash space)
+
+- updated translations.
+
+### Additional information
+
+Other info you consider important.
+-->
+
+### Release information
+
+- Name:
+- Author:
+- Repo:
+- Version:
+- Update channel:
+- NVDA compatibility:
+
+### Changelog
+
+### Additional information
+


### PR DESCRIPTION
Hi,

I created another template for PR.

In short, this presents a comment with a filled template as example, and then the blank template, to fill-in without you have to delete info and parenthesis around.

I use gh (github-cli), so I don't know if it could be good for web interface too... In this branch should be selectable as alternative to default, but I was not able to test it, unfortunately (I suspect it can be selected only when placed in master branch).

Please, consider this small improvement.
