### PR TITLE
New addon Screenshots Wizard

### DIFF
--- a/get.php
+++ b/get.php
@@ -114,6 +114,7 @@ $addons = array(
 	"rsy" => "https://github.com/nvdaes/reportSymbols/releases/download/7.0/reportSymbols-7.0.nvda-addon",
 	"rsy-dev" => "https://github.com/nvdaes/reportSymbols/releases/download/7.0/reportSymbols-7.0.nvda-addon",
 	"rsy-o" => "https://github.com/nvdaes/reportSymbols/releases/download/3.6/reportSymbols-3.6.nvda-addon",
+	"scrsw" => "https://github.com/javidominguez/screenshots/releases/download/1.0/screenshots-1.0.nvda-addon",
 	"searchwith" => "https://github.com/ibrahim-s/searchWith/releases/download/v2.0/searchWith-2.0.nvda-addon",
 	"sentencenav" => "https://github.com/mltony/nvda-sentence-nav/releases/download/v2.11/SentenceNav-2.11.nvda-addon",
 	"soundsplitter" => "https://github.com/josephsl/soundSplitter/releases/download/22.03/soundSplitter-22.03.1.nvda-addon",


### PR DESCRIPTION
<!-- Please read and fill in the following template.

Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
-->

### Release information
- Name: Screenshots Wizard
- Author: Javi Dominguez
- Repo: https://github.com/javidominguez/screenshots/
- Version: 1.0
- Update channel: stable
- NVDA compatibility: 2021.2 and beyond

### Changelog (mention changes in separate lines starting with dash space)
- New addon
- 2022.1 compatible

### Additional information

This add-on provides a wizard to take screenshots of the entire screen or specific areas such as objects, windows, etc. It is activated by the _print screen_ key which on standard keyboards is usually the first of the group of three to the right of F12. If you prefer to use another, it can be configured in the NVDA preferences, input gestures.

When the wizard is invoked, a virtual rectangle is created around the object with focus and a layer of keyboard commands is activated. See [documentation](https://github.com/javidominguez/screenshots/raw/95c7162db7d706de1c7a806fc6ace931b72a3225/readme.md) to know available commands in this layer.