### PR TITLE
Access8Math 3.3

### DIFF
--- a/get.php
+++ b/get.php
@@ -1,6 +1,6 @@
 <?php
 $addons = array(
-	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.2/Access8Math-3.2.nvda-addon",
+	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.3/Access8Math-3.3.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
 	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03.26/applicationDictionary-2022.03.26.nvda-addon",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Access8Math
- Author: Tseng Woody
- Repo: https://github.com/tsengwoody/Access8Math
- Version: 3.3
- Update channel: stable
- NVDA compatibility: 2019.3~2022.1

### Changelog (mention changes in separate lines starting with dash space)

*	Add built-in editor using traditional editing area because of windows 11 changed to UIA editing area
*	built-in editor new/open/save feature
*	Access8Math language initial setting is based on NVDA language setting
*	Improved speech and braille display in virtual menus
*	Compatibility with NVDA 2022.1
*	Fixed marked menu cannot open when document is empty
*	Fixed translate LaTeX/AsciiMath feature
*	Fixed HTML document rendering problem when HTML document display setting choice text option

### Additional information

