### PR TITLE
Update Weather_Plus to 8.9

### DIFF
--- a/get.php
+++ b/get.php
@@ -151,7 +151,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.05/wintenApps-22.05.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
-	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.8.nvda-addon",
+	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Weather_Plus
- Author: Adriano Barbieri
- Repo: https://github.com/ruifontes/weather_plus
- Version: 8.9
- Update channel: stable
- NVDA compatibility: 2017.3 and beyond

### Changelog
- Complement in secure screens mode, with this version they are also disabled the "Documentation" and "Check for updates" menus.
### Additional information
PR created on behalf of the add-on author, with info provided by him (privately).
