### PR TITLE
Browser Nav 2.4 (Tony Malykh)

### DIFF
--- a/get.php
+++ b/get.php
@@ -12,7 +12,7 @@ $addons = array(
 	"bgt" => "https://github.com/sykesman/NVDA-BGT/releases/download/1.0-dev/bgt_lullaby-1.0-dev.nvda-addon",
 	"brlext" => "https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest",
 	"brlext-dev" => "https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest?channel=dev",
-	"browsernav" => "https://github.com/mltony/nvda-browser-nav/releases/download/v1.15.1/browsernav-1.15.nvda-addon",
+	"browsernav" => "https://github.com/mltony/nvda-browser-nav/releases/download/v2.4/browsernav-2.4.nvda-addon",
 	"btaudio" => "https://github.com/mltony/nvda-bluetooth-audio/releases/download/v1.4/bluetoothaudio-1.4.nvda-addon",
 	"cac" => "https://github.com/hkatic/clock/releases/download/v22.01/clock-22.01.nvda-addon",
 	"cac-dev" => "https://github.com/hkatic/clock/releases/download/v22.01/clock-22.01.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Browser Nav
- Author: Tony Malykh
- Repo: https://github.com/mltony/nvda-browser-nav
- Version: 2.4
- Update channel: stable
- NVDA compatibility: 2019.3 and later

### Changelog (mention changes in separate lines starting with dash space)
From 1.15:

- Introduces bookmarks: QuickJump, QuickClick, SkipClutter and Hierarchical.
- Introduces optional ignoring focus events and muting live regions.
- Compatibility with NVDA 2022.
- Fixed QuickNav T command to jump to the first cell of the table.
- Bugfixes.
- Works better with Chrome v100
- Better warning messages.
- Improved certain use cases with MS Outlook
- Fixed broken option URLMatch.DOMAIN.
- Removed list and listItem from default configuration skipClutter item.

### Additional information
CC @mltony 
