### PR TITLE
add 'mathcat' to the list

### DIFF
--- a/get.php
+++ b/get.php
@@ -72,6 +72,7 @@ $addons = array(
 	"killnvda" => "https://github.com/tspivey/killNVDA/releases/download/v0.2/killNVDA-0.2.nvda-addon",
 	"lambda" => "https://github.com/lambda-nvda/lambdaNvda/releases/download/1.4.1/lambda-1.4.1.nvda-addon",
 	"lambda-dev" => "https://github.com/lambda-nvda/lambdaNvda/releases/download/1.4.1/lambda-1.4.1.nvda-addon",
+	"mathcat" => "https://github.com/NSoiffer/MathCATForPython/releases/download/v.0.1.14/MathCAT-0.1.14.nvda-addon",
 	"mp3dc" => "https://github.com/abdel792/mp3DirectCut/releases/download/v21.11/mp3DirectCut-21.11.nvda-addon",
 	"mp3dc-dev" => "https://github.com/abdel792/mp3DirectCut/releases/download/v21.11-dev/mp3DirectCut-21.11-dev.nvda-addon",
 	"mirc" => "mirc-1.6.nvda-addon",


### PR DESCRIPTION
<!-- Please read and fill in the following template.

Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
-->

### Release information
- Name (Example, Add-on Updater):  MathCAT
- Author (example, Your Name): Neil Soiffer
- Repo (example, https://github.com/yourname/addonName):  https://github.com/NSoiffer/MathCATForPython
- Version (example, 21.07): 0.1.14
- Update channel (example, stable, dev or stable and dev): stable
- NVDA compatibility (example, 2021.1 and beyond): 2018.1 and beyond

### Changelog (mention changes in separate lines starting with dash space)

### Additional information
MathCAT is designed to eventually replace MathPlayer because MathPlayer is no longer supported. MathCAT generates speech and braille from MathML. The speech is enhanced with prosody so that it sounds more natural. The speech can be navigated in three modes using the same commands as MathPlayer. In addition, the navigation node is indicated on a braille display. Both Nemeth and UEB technical are supported.

MathCAT adds a settings menu to NVDA's preferences menu. In the settings menu, numerous options in MathCAT can be set to control the speech, navigation, and braille.
