### PR TITLE
Add development version of add-on for  Becky! Internet Mail

### DIFF
--- a/get.php
+++ b/get.php
@@ -8,6 +8,7 @@ $addons = array(
 	"audiochart" => "https://github.com/mltony/nvda-audio-chart/releases/download/v1.3/audioChart-1.3.nvda-addon",
 	"bc" => "bitChe-2.8.nvda-addon",
 	"bc-dev" => "bitChe-2.8.nvda-addon",
+	"becky-dev" => "https://github.com/lukaszgo1/Becky/releases/download/V0.3-dev/Becky-0.3-dev.nvda-addon",
 	"beepkeyboard" => "https://github.com/davidacm/beepKeyboard/releases/download/1.8/beepKeyboard-1.8.nvda-addon",
 	"bgt" => "https://github.com/sykesman/NVDA-BGT/releases/download/1.0-dev/bgt_lullaby-1.0-dev.nvda-addon",
 	"brlext" => "https://andreabc.net/projects/NVDA_addons/BrailleExtender/latest",


### PR DESCRIPTION
### Release information
- Name: Becky
- Author: Łukasz Golonka (@lukaszgo1)
- Repo: https://github.com/lukaszgo1/Becky/
- Version: 0.3-dev
- Update channel : dev
- NVDA compatibility: 2019.2 and beyond 

### Changelog (mention changes in separate lines starting with dash space)
- Initial version available from the add-ons web site
### Additional information
Source code of the add-on has not been reviewed. I've asked for reviews [on add-ons list](https://nvda-addons.groups.io/g/nvda-addons/topic/91432033#18947)but since Becky! is quite esoteric piece of software it is likely  no other add-on developer except me is using it.