### PR TITLE
Update winWizard to version 5.0.4

### DIFF
--- a/get.php
+++ b/get.php
@@ -156,7 +156,7 @@ $addons = array(
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
-	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.3/winWizard-5.0.3.nvda-addon",
+	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.4/winWizard-5.0.4.nvda-addon",
 	"wordnav" => "https://github.com/mltony/nvda-word-nav/releases/download/v1.7/wordNav-1.7.nvda-addon",
 	"zoom" => "https://github.com/mohammad-suliman/zoom-enhancements/releases/download/v1.1.2/zoomEnhancements-1.1.2.nvda-addon",
 );


### PR DESCRIPTION
### Release information
- Name: Win Wizard
- Author: Oriol Gómez, current maintenance by Łukasz Golonka
- Repo: https://github.com/lukaszgo1/winWizard/
- Version: 5.0.4
- Update channel: stable
- NVDA compatibility: 2019.3 and beyond

### Changelog (mention changes in separate lines starting with dash space)
- Compatibility with NVDA 2022.1
- It is now possible to disable confirmation beeps in the add-ons settings panel
- Update translations

### Additional information

