### PR TITLE
Windows App Essentials 22.07

### DIFF
--- a/get.php
+++ b/get.php
@@ -150,7 +150,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.06/wintenApps-22.06.1.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.07/wintenApps-22.07.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.07
- Update channel: stable
- NVDA compatibility: 2021.3 and later
- Sha256: 5935a2e20cb27655f7d373237f43b38f14298b32d57f654bc39824c0e06c8468

### Changelog (mention changes in separate lines starting with dash space)
- Initial support for Windows 11 Version 22H2 (2022 update).
- In Windows 10, NVDA will present a list of supported releases when attempting to install the add-on on unsupported Windows 10 releases. Currently supported releases are Windows 10 21H1 (19043), 21H2 (19044), and Server 2022 (20348). Consequently, installing and using the add-on on Windows Insider Preview builds earlier than 20348 is no longer supported unless Windows 10 feature updates are released from these builds.
- Mail: Table navigation commands for mail items is deprecated and will be removed in a future release.

### Additional information
