### PR TITLE
New add-on: NVDA Dev & Test Toolbox (V2.1)

### DIFF
--- a/get.php
+++ b/get.php
@@ -82,6 +82,7 @@ $addons = array(
 	"mush" => "mushClient-1.3.nvda-addon",
 	"nb" => "https://github.com/ABuffEr/noBeepsSpeechMode/releases/download/v5.1/noBeepsSpeechMode-5.1.nvda-addon",
 	"nb-old" => "https://github.com/ABuffEr/noBeepsSpeechMode/releases/download/v4.0/noBeepsSpeechMode-4.0.nvda-addon",
+	"ndtt" => "https://github.com/CyrilleB79/NVDA-Dev-Test-Toolbox/releases/download/V2.1/nvdaDevTestToolbox-2.1.nvda-addon",
 	"newfon" => "https://github.com/DraganRatkovich/newfon/releases/download/2022.04.16/newfon-2022.04.16.nvda-addon",
 	"NotepadPlusPlus" => "https://files.derekriemer.com/NotepadPlusPlus-2022.05.1.nvda-addon",
 	"numpadNav" => "https://github.com/opensourcesys/numpadNavMode/releases/download/1.5/numpadNavMode-1.5.nvda-addon",


### PR DESCRIPTION

### Release information
- Name: NVDA Dev & Test Toolbox
- Author: Cyrille Bougot
- Repo: https://github.com/CyrilleB79/NVDA-Dev-Test-Toolbox
- Version: 2.1
- Update channel: stable
- NVDA compatibility: 2019.2 and beyond

### Changelog (mention changes in separate lines starting with dash space)

#### Release V2.1
- Various bugfixes and code refactoring/cleaning to address all use cases: all supported versions, installed vs. run from source, etc. (contribution from Łukasz Golonka)
- Rewriting of the compa module (contribution from Łukasz Golonka)
- The restart dialog can now be opened only once.
- The object explorer shortcuts are now unassigned by default and need to be mapped by the user.
- With the object explorer, a double-press to call the script to report the current object's property now displays the reported information in a browseable message.

#### Release V2.0 
- New feature: Enhanced restart dialog to specify some extra options when restarting NVDA.
- New feature: extended description mode.
- Play error sound feature harmonized between pre and post 2021.3 versions of NVDA.
- New feature: Log reader commands are now available in the log viewer and also optionally in edit fields or webpages.
- New feature: In the Python console, an openCodeFile function is available to view the source code of an object.
- Some features are now disabled in secure mode for security reasons.
- The add-on's compatibility range has been extended (from 2019.2 to 2021.1).
- Releases are now performed with GitHub action instead of appVeyor.




### Additional information
First release on https://addons.nvda-project.org
