### PR TITLE
Windows App Essentials 22.08

### DIFF
--- a/get.php
+++ b/get.php
@@ -152,7 +152,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.07/wintenApps-22.07.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.08/wintenApps-22.08.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.08
- Update channel: stable
- NVDA compatibility: 2021.3 and later
- Sha256: 404e593c9b371a192d1d6581080fa01b97e82e34f3ff2098752cad3a1757cb03

### Changelog (mention changes in separate lines starting with dash space)
- Added support for automatic add-on updates feature from Add-on Updater add-on. In particular, the add-on will not install if using unsupported Windows releases.
- Event debug log for events added by this add-on (drag complete, drag drop effect, drop target dropped) are logged from event handlers themselves rather than  through a dedicated method. This makes debug log for events more concise.
- Microsoft Solitaire Collection: In version 4.13 and later, NVDA will announce card (suit and rank) labels provided by the app itself. As a result, support for Solitaire Collection is deprecated and will be removed in a future add-on release.
- Modern keyboard: Added support for Suggested Actions backported to build 22622 (Windows 11 22H2 beta).
- Settings: In Windows 11 22H2 and later, NVDA will announce the name of the update being downloaded from Windows Update. This works best with selective UIA event registration off, but if this setting is enabled, move to updates list as soon as it appears so NVDA can detect and announce update progress.
- Settings: In newer Windows 11 21H2 releases, optional update title will be announced if shown.

### Additional information
This is the last version to support NVDA 2021.3 and Windows 10 Version 21H1 (May 2021 Update/build 19043).
