### PR TITLE
Windows App Essentials 22.08.1

### DIFF
--- a/get.php
+++ b/get.php
@@ -152,7 +152,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.08/wintenApps-22.08.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.08/wintenApps-22.08.1.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.08.1
- Update channel: stable
- NVDA compatibility: 2021.3 and later
- Sha256: ee73751bf4a404cc5ebbe8c32b48b5bfc9fde72c5a8321530f8bb42fee022df4

### Changelog (mention changes in separate lines starting with dash space)
- Compatibility with NVDA 2022.3.
- Initial support for Windows 10 Version 22H2 (2022 Update), not to be confused with Windows 11 Version 22H2.

### Additional information
This update introduces support for Windows 10 Version 22H2. As a result, it supports Windows 10 21H1, 21H2, 22H2, Windows Server 2022, Windows 11 21H2, 22H2, and Insider Preview.
