### PR TITLE
Windows App Essentials 22.09

### DIFF
--- a/get.php
+++ b/get.php
@@ -152,7 +152,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.08/wintenApps-22.08.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.09/wintenApps-22.09.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.09
- Update channel: stable
- NVDA compatibility: 2022.2 and later
- Sha256: 1939d637e1526c209b06e0f84705dc0b704249184d353c1ce8c63629e6020ade

### Changelog (mention changes in separate lines starting with dash space)
- NVDA 2022.2 or later is required, more so for security (2022.2.2 or later is recommended).
- Windows 10: Requires Version 21H2 or later.
- Various features and fixes that were included with the add-on are now part of NVDA. NVDA 2022.1 include support for Windows 11 Calculator, announcing history and memory items in Windows 10 Calculator, fixing inability to use arrow keys to review emojis in Windows 11 emoji panel, and resolving text output repetition in Windows Terminal 1.12.10733 and later. NVDA 2022.2 include announcing more results including scientific mode command results in Calculator, announcing search result details in Start menu again, detecting Windows 11 UI elements when interacting with mouse and/or touch, and announcing status bar in Windows 11 Notepad if shown.
- Removed app modules for Windows 10 and 11 Calculator, Mail, Microsoft Solitaire Collection, and Windows 11 Notepad. NVDA includes Calculator and Notepad app modules, removed table navigation commands for mail items from Mail app module, and cards are labeled in Solitaire Collection.
- The list of supported releases is also shown on Windows 11 systems when attempting to install the add-on on unsupported releases. Currently supported releases are 21H2 (22000), 22H2 (22621/22622 beta), and Windows Insider builds above 25000.
- Item status changes are announced in more apps including Visual Studio Community 2022.

### Additional information
