### PR TITLE
SMB v 22.8 - Add-on for Sao Mai Braille program

### DIFF
--- a/get.php
+++ b/get.php
@@ -1,5 +1,6 @@
 <?php
 $addons = array(
+	"smb" => "https://github.com/Sao-Mai-Center/SMB/releases/download/22.8/SMB-22.8.nvda-addon",
 	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.3/Access8Math-3.3.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
 	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03.26/applicationDictionary-2022.03.26.nvda-addon",

--- a/get.php
+++ b/get.php
@@ -1,7 +1,6 @@
 <?php
 $addons = array(
-	"smb" => "https://github.com/Sao-Mai-Center/SMB/releases/download/22.8/SMB-22.8.nvda-addon",
-	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.3/Access8Math-3.3.nvda-addon",
+		"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.3/Access8Math-3.3.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
 	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03.26/applicationDictionary-2022.03.26.nvda-addon",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",
@@ -124,6 +123,7 @@ $addons = array(
 	"scrsw" => "https://github.com/javidominguez/screenshots/releases/download/1.0/screenshots-1.0.nvda-addon",
 	"searchwith" => "https://github.com/ibrahim-s/searchWith/releases/download/v2.1/searchWith-2.1.nvda-addon",
 	"sentencenav" => "https://github.com/mltony/nvda-sentence-nav/releases/download/v2.12/SentenceNav-2.12.nvda-addon",
+	"smb" => "https://github.com/Sao-Mai-Center/SMB/releases/download/22.8/SMB-22.8.nvda-addon",
 	"soundsplitter" => "https://github.com/josephsl/soundSplitter/releases/download/22.03/soundSplitter-22.03.1.nvda-addon",
 	"spie" => "https://www.nvaccess.org/files/nvda-addons/speechPlayerInEspeak-0.4.nvda-addon",
 	"splogger" => "https://github.com/opensourcesys/speechLogger/releases/download/22.2.1/speechLogger-22.2.1.nvda-addon",

--- a/get.php
+++ b/get.php
@@ -1,6 +1,6 @@
 <?php
 $addons = array(
-		"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.3/Access8Math-3.3.nvda-addon",
+	"access8math" => "https://github.com/tsengwoody/Access8Math/releases/download/v3.3/Access8Math-3.3.nvda-addon",
 	"addonshelp" => "https://github.com/ruifontes/addonsHelp/releases/download/2022.03/addonsHelp-2022.03.nvda-addon",
 	"appdict" => "https://github.com/ruifontes/applicationDictionary-/releases/download/2022.03.26/applicationDictionary-2022.03.26.nvda-addon",
 	"ath" => "https://github.com/mush42/Audio-Themes-NVDA-Add-on/releases/download/v5.1/AudioThemes3D-5.1.nvda-addon",


### PR DESCRIPTION
<!-- Please read and fill in the following template.

Go to lines starting with a dash (-) and place the required information for each item after the colon followed by space.
-->

### Release information
- Name (Example, Add-on Updater): SMB
- Author (example, Your Name): Sao Mai Technology Team
- Repo (example, https://github.com/yourname/addonName): https://github.com/Sao-Mai-Center/SMB
- Version (example, 21.07): 22.8
- Update channel (example, stable, dev or stable and dev): stable
- NVDA compatibility (example, 2021.1 and beyond): 2019.3 and beyond):

### Changelog (mention changes in separate lines starting with dash space)
- 2022.8: compatible with NVDA 2022.3
### Additional information
Sao Mai Braille (SMB) is a free rich text editing and Braille translation software for Windows, developed by [Sao Mai Center for the Blind](https://www.saomaicenter.org/en)
This is a small add-on to make NVDA screen reader more accessible to SMB's interface.
More info about this program can be found at <https://www.saomaicenter.org/en/smsoft/smb>
