### PR TITLE
Windows App Essentials 22.09.1

### DIFF
--- a/get.php
+++ b/get.php
@@ -153,7 +153,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.09/wintenApps-22.09.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.09/wintenApps-22.09.1.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.09.1
- Update channel: stable
- NVDA compatibility: 2022.2 and later
- Sha256: 42c3b79585e9cea9b067de1d23de01b2882adbbb7dc0e1fb455bf6f7e4fd6c4e

### Changelog (mention changes in separate lines starting with dash space)
- Resolves drag and drop effect announcement repetitions in NVDA alpha snapshots. This will result in no focus announcement when drag and drop completes in some cases.

### Additional information
This release partially backports work done in development builds of the add-on. Focus announcement when drag completes is actually planned to be removed in the next stable (and a major) version of the add-on. This release also prepares to hand off drag and drop effect announcement to NVDA Core - ideally people should install the add-on before installing a future NVDA version with drag and drop effect announcement added.
