### PR TITLE
Office Desk 22.10 (initial version)

### DIFF
--- a/get.php
+++ b/get.php
@@ -95,6 +95,7 @@ $addons = array(
 	"objLoc" => "https://github.com/josephsl/objLocationTones/releases/download/22.06/objLocTones-22.06.nvda-addon",
 	"objPad" => "https://github.com/josephsl/objPad/releases/download/22.06/objPad-22.06.nvda-addon",
 	"ocr" => "https://github.com/lukaszgo1/nvda-ocr/releases/download/v2.2/ocr-2.2.nvda-addon",
+	"officedesk" => "https://github.com/josephsl/officeDesk/releases/download/22.10/officeDesk-22.10.nvda-addon",
 	"oid-dev" => "https://github.com/larry801/online_ocr/releases/download/0.17-dev/onlineOCR-0.17-dev.nvda-addon",
 	"outlookextended" => "https://github.com/CyrilleB79/outlookExtended/releases/download/V1.9/outlookExtended-1.9.nvda-addon",
 	"outlookextended-dev" => "https://github.com/CyrilleB79/outlookExtended/releases/download/V1.9/outlookExtended-1.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Office Desk
- Author: Joseph Lee and others
- Repo: https://github.com/josephsl/officedesk
- Version: 22.10
- Update channel: stable
- NVDA compatibility: 2022.2 and later
- Sha256: dc728609ee600aa4adb1f61b2f2fd8cbdcd990c861d474304470f61e4c0134d8

### Changelog (mention changes in separate lines starting with dash space)
- Initial release.
- In backstage view, NVDA will announce search count when search results appear, as well as announcing results when up 
- In Word, NVDA will no longer announce formatting changes such as bold and italic onoff multiple times.and down arrow keys are pressed.
- In Word Envelopes dialog, NVDA will announce edit field labels.

### Additional information
Office Desk is a new add-on designed to serve as a collaborative project to improve support for Microsoft (Office) 365 applications such as Word and Exce. This initial version includes the main Ofice Desk global plugin and app modules for Word. There are other app modules included, mostly for expansion in future releases.

In some ways, Office Desk resembles Windows App Essentials in structure. But I (Joseph Lee) would like to tak e hands-off approach with Office Desk - rather than lead the project directly, I would like to provide a visoin and serve as initial release manager, occasionally providing fixes here and there. Note that this add-on does not replace Outlook Extended and Word Access (the latter is not part of the community add-ons website at the moment).

Thanks.