### PR TITLE
Windows App Essentials 22.10

### DIFF
--- a/get.php
+++ b/get.php
@@ -153,7 +153,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.09/wintenApps-22.09.1.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.10/wintenApps-22.10.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.10
- Update channel: stable
- NVDA compatibility: 2022.2 and later
- Sha256: d3eda5ab30776dab608ac6a29a6956086271a38b174dc86da0f155b63314690c

### Changelog (mention changes in separate lines starting with dash space)
- The following UIA property changes are recognized: drag is grabbed (recognized as a distinct state), drop target effect.
- UIA drag start/cancel/complete events are recognized once again, this time as a state change events.
- NVDA will announce "dragging" when dragging certain items such as when arranging Windows 10 Start menu tiles by pressing Alt+Shift+arrow keys.
- Drop target dropped UIA event is removed. As a result, NVDA will no longer announce position of the newly dragged item by faking focus events once drag and drop operation completes, replaced by announcing drag drop and drop target effects while drag and drop is in progress.
- Debug logging for drag and drop events is now handled by Event Tracker add-on, more so if using NVDA 2022.4 (under development).
- Due to verbosity issues, item status change announcements in more apps has been removed.

### Additional information
