### PR TITLE
Windows App Essentials 22.11

### DIFF
--- a/get.php
+++ b/get.php
@@ -155,7 +155,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.10/wintenApps-22.10.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.11/wintenApps-22.11.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.11
- Update channel: stable
- NVDA compatibility: 2022.2 and later
- Sha256: 4f712a3a66f6d4accdcd60498b6977820907d155fa86872b1884ff7243e23146

### Changelog (mention changes in separate lines starting with dash space)
- Transferred Word 365 formatting announcement fix to Office Desk add-on.
- The ability to toggle UIA notification announcements from apps such as Calculator via "Report notifications" setting found in NVDA's object presentation settings panel is deprecated and will be removed in a future add-on release.
- Removed microphone toggle announcement from everywhere except File Explorer in Windows 11 22H2 and later. As a workaround, minimize all apps and then press Alt+Windows+K to toggle microphone status.
- In Windows 11, NVDA will announce search highlights in Start menu when it opens.
- Modern keyboard: Suggested Actions is now part of Windows 11 22H2 Moment 1 (enabled in build 22621).
- People: Recognizing contacts search field and suggestions are deprecated and will be removed in a future add-on release as NVDA 2023.1 will provide a more generic support for search suggestions in more apps such as People app.

### Additional information
