### PR TITLE
Windows App Essentials 22.12

### DIFF
--- a/get.php
+++ b/get.php
@@ -155,7 +155,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.11/wintenApps-22.11.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.12/wintenApps-22.12.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 22.12
- Update channel: stable
- NVDA compatibility: 2022.2 and later
- Sha256: f560fca6996455b576073d1c32a783a010415e37dc5ae149498fe2fcb56028dd

### Changelog (mention changes in separate lines starting with dash space)
- Supported releases and builds across Windows 10 and 11 will be displayed if attempting to install the add-on on unsupported Windows releases including releases earlier than 10 and unsupported feature updates.
- Removed most of Windows version detection code from WinAppObjs global plugin as it was ineffective in preventing the add-on from running in unsupported Windows releases.
- Windows 11: If running on 22H2 beta builds (22622/22623), NVDA will recognize this fact and record this information in the log.
- Windows 11 22H2 beta: Requires build 22623.
- Transferred virtual desktop switch announcement from WinAppObjs global plugin to CSRSS (client/server runtime subsystem) ap module as announcements come from CSRSS.
- Voice access: Microphone toggle state is announced once again in Insider Preview build 25200 series.

### Additional information
