### PR TITLE
Update Weather_Plus to 9.2

### DIFF
--- a/get.php
+++ b/get.php
@@ -158,7 +158,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.12/wintenApps-22.12.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
-	"wetp" => "https://www.nvda.it/files/plugin/weather_plus8.9.nvda-addon",
+	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.1.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.4/winWizard-5.0.4.nvda-addon",

--- a/get.php
+++ b/get.php
@@ -158,7 +158,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.12/wintenApps-22.12.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
-	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.1.nvda-addon",
+	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.2.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.4/winWizard-5.0.4.nvda-addon",


### PR DESCRIPTION
### Release information

- Name: Weather_Plus
- Author: Adriano Barbieri
- Repo: not provided
- Version: 9.2
- Update channel: stable
- NVDA compatibility: 2017.3 and beyond

### Changelog
- Fixed bug when closing the weather report and details view window that crashed nvda.
- Fixed bug when closing the dialog after using the option View the output in a window.

### Additional information
Supersedes PR #437
