### PR TITLE
Windows App Essentials 23.01

### DIFF
--- a/get.php
+++ b/get.php
@@ -155,7 +155,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/22.12/wintenApps-22.12.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/23.01/wintenApps-23.01.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.2.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 23.01
- Update channel: stable
- NVDA compatibility: 2022.3 and later
- Sha256: d8e3973faa32a375ad414ef911478919cfeb695841761824f6ac5e4fc0f3a742

### Changelog (mention changes in separate lines starting with dash space)
- NVDA 2022.3 or later is required.
- Removed app module for People app.
- Removed the ability to toggle UIA notification announcements from apps such as Calculator via "Report notifications" setting found in NVDA's object presentation settings panel.
- In Windows 11 22H2 Moment 2, redesigned system tray overflow area can be detected properly when using mouse and/or touch interaction.
- NVDA will record processor architecture for the current Windows installation (x86/32-bit, AMD64, ARM64) in the log when the add-on starts.
- Maps: NVDA will no longer interrupt speech when focused on items other than the map control in some cases.

### Additional information
