### PR TITLE
Windows App Essentials 23.02

### DIFF
--- a/get.php
+++ b/get.php
@@ -155,7 +155,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/23.01/wintenApps-23.01.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/23.02/wintenApps-23.02.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.3.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 23.02
- Update channel: stable
- NVDA compatibility: 2022.4 and later
- Sha256: e2c488464ac97b510aacfebfc2a3bbce5cd9f7b1e60c15e5cf487dae95e2156c

### Changelog (mention changes in separate lines starting with dash space)
- NVDA 2022.4 or later is required.
- Various features and fixes that were included with the add-on are now part of NVDA. These include announcing "dragging" when an item is about to be dragged and announcing drag and drop target effects.
- Removed additional UIA event tracking facility as the last set of additional events (drag and drop) are included in NVDA 2022.4.
- Improved Windows 10 and 11 taskbar experience, including announcing results of rearranging icons when pressing Alt+Shift+left/right arrow keys (Windows 11 prior to build 25267) and reporting item position when moving through taskbar icons (Windows 10 and 11 prior to build 25281).
- In Windows 11 22H2, Open With dialog can be navigated using mouse and/or touch interaction.
- NVDA will announce empty folder text inside an empty folder in File Explorer.
- In aps such as File Explorer and Notepad where tabbed windows are supported, NVDA will announce the name and the position of tabs when switching between them.
- Notepad (Windows 11): NVDA will once again announce status bar contents in version 11.2212 or later, particularly when multiple tabs are open.

### Additional information
