### PR TITLE
Add Vocalizer Automotive 2.1.4

### DIFF
--- a/get.php
+++ b/get.php
@@ -155,6 +155,7 @@ $addons = array(
 	"vlc" => "https://github.com/javidominguez/VLC/releases/download/2.14/VLC-2.14.nvda-addon",
 	"vlc-dev" => "https://github.com/javidominguez/VLC/releases/download/2.13/VLC-2.13.nvda-addon",
 	"vent" => "Ventrilo-1.0-dev.nvda-addon",
+	"vocalizerautomotive" => "https://github.com/ruifontes/vocalizer_automotive_driver/releases/download/2.1.4/vocalizer_automotive_driver-2.1.4.nvda-addon",
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/23.02/wintenApps-23.02.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",


### PR DESCRIPTION
### Release information

- Name: Nuance Vocalizer 5.5 Driver
- Author: Tiflotecnia, LDA.
- Repo: https://github.com/ruifontes
- Version: 2.1.4
- Update channel: stable
- NVDA compatibility: 2019.3 and beyond (including 2023.1)

### Changelog

- Renaming the internal name of synth from "vocalizer" to "vocalizerAutomotive" to allow coexistence with the CodeFactory add-on;
- Changing manifest.ini to be compatible with NVDA 2023.1;
- Introducing automatic update system.

### Additional information

[Announcement on add-ons mailing list](https://nvda-addons.groups.io/g/nvda-addons/message/20297)
