### PR TITLE
Update Weather_Plus to 9.4

### DIFF
--- a/get.php
+++ b/get.php
@@ -158,7 +158,7 @@ $addons = array(
 	"w10" => "https://github.com/josephsl/wintenApps/releases/download/23.02/wintenApps-23.02.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
-	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.3.nvda-addon",
+	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.4.nvda-addon",
 	"winmag" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winmag-dev" => "https://github.com/CyrilleB79/winMag/releases/download/V2.0/winMag-2.0.nvda-addon",
 	"winwizard" => "https://github.com/lukaszgo1/winWizard/releases/download/V5.0.4/winWizard-5.0.4.nvda-addon",


### PR DESCRIPTION
### Release information

- Name: Weather_Plus
- Author: Adriano Barbieri
- Repo: Not provided
- Version: 9.4
- Update channel: stable
- NVDA compatibility: 2017.3 and beyond (including 2023.1)

### Changelog

- Compatible with NVDA 2023.1

### Additional information

Requested on behalf of the author, who sent me the download link privately.
