### PR TITLE
Windows App Essentials 23.03

### DIFF
--- a/get.php
+++ b/get.php
@@ -157,7 +157,7 @@ $addons = array(
 	"vocalizerexpressive" => "https://github.com/ruifontes/vocalizer_expressive_driver/releases/download/3.1.8/vocalizer_expressive_driver-3.1.8.nvda-addon",
 	"virtualaudiocable" => "https://www.dlee.org/vac/NVDA/vac.nvda-addon",
 	"vocalizerautomotive" => "https://github.com/ruifontes/vocalizer_automotive_driver/releases/download/2.1.4/vocalizer_automotive_driver-2.1.4.nvda-addon",
-	"w10" => "https://github.com/josephsl/wintenApps/releases/download/23.02/wintenApps-23.02.nvda-addon",
+	"w10" => "https://github.com/josephsl/wintenApps/releases/download/23.03/wintenApps-23.03.nvda-addon",
 	"w10-dev" => "https://www.josephsl.net/files/nvdaaddons/getupdate.php?file=w10-dev",
 	"wc" => "https://github.com/ruifontes/wordCount/releases/download/2022.03/wordCount-2022.03.nvda-addon",
 	"wetp" => "https://www.nvda.it/files/plugin/weather_plus9.4.nvda-addon",


### PR DESCRIPTION
### Release information
- Name: Windows App Essentials
- Author: Joseph Lee, Derek Riemer and contributors
- Repo: https://github.com/josephsl/wintenapps
- Version: 23.02
- Update channel: stable
- NVDA compatibility: 2022.4 and later
- Sha256: eeff4cb46e400d458167ea74e38a5394fa76cd782d0f3bcb5d2285818340fbaa

### Changelog (mention changes in separate lines starting with dash space)
- Added type information to more areas of the add-on source code.
- Windows 11: NVDA will no longer appear to do nothing or play error tones when using the mouse to review taskbar items at the cost of not announcing position information sometimes.
- Windows 11: NVDA will no longer record information on 22H2 beta builds.
- MSN Weather: Removed "no more weather data" message when arrowing up and down from weather items list.
- Notepad (Windows 11): NVDA will no longer say "back" when retrieving status bar contents in Notepad 11.2301 and later, particularly after opening and closing Notepad settings (Alt+S).

### Additional information
